### PR TITLE
Add opaque and reveal

### DIFF
--- a/gobra-mode.el
+++ b/gobra-mode.el
@@ -475,6 +475,7 @@
                          "ensures"
                          "preserves"
                          "trusted"
+			 "opaque"
                          "pred"
                          "pure"
                          "forall"

--- a/gobra-mode.el
+++ b/gobra-mode.el
@@ -476,6 +476,7 @@
                          "preserves"
                          "trusted"
 			 "opaque"
+			 "reveal"
                          "pred"
                          "pure"
                          "forall"


### PR DESCRIPTION
Adds support for `opaque` and `reveal` which were introduced in https://github.com/viperproject/gobra/pull/715#issue-2057115777.